### PR TITLE
Проверка на активацию помощников

### DIFF
--- a/ng-grecaptcha.php
+++ b/ng-grecaptcha.php
@@ -5,6 +5,11 @@ if (!defined('NGCMS')) {
     die('HAL');
 }
 
+// Если не активированы помощники, то выходим.
+if (! getPluginStatusActive('ng-helpers')) {
+    return false;
+}
+
 // Подгрузка библиотек-файлов плагина.
 loadPluginLibrary('ng-grecaptcha', 'autoload');
 


### PR DESCRIPTION
Помощников необходимо учитывыать, так как плагин привязан к действию `core`.